### PR TITLE
fastboot-protocol: Handle response data with null bytes

### DIFF
--- a/fastboot-protocol/src/protocol.rs
+++ b/fastboot-protocol/src/protocol.rs
@@ -73,6 +73,12 @@ pub enum FastBootResponseParseError {
     /// Unknown response type
     #[error("Unknown response type")]
     UnknownReply,
+    /// Couldn't parse response type
+    #[error("Couldn't parse response type")]
+    ParseType,
+    /// Couldn't parse response payload
+    #[error("Couldn't parse response payload")]
+    ParsePayload,
     /// Couldn't parse DATA length
     #[error("Couldn't parse DATA length")]
     DataLength,
@@ -115,8 +121,10 @@ impl<'a> FastBootResponse {
         if bytes.len() < 4 {
             Err(FastBootResponseParseError::UnknownReply)
         } else {
-            let resp = std::str::from_utf8(&bytes[0..4]).unwrap();
-            let data = std::str::from_utf8(bytes_slice_null(&bytes[4..])).unwrap();
+            let resp =
+                std::str::from_utf8(&bytes[0..4]).or(Err(FastBootResponseParseError::ParseType))?;
+            let data = std::str::from_utf8(bytes_slice_null(&bytes[4..]))
+                .or(Err(FastBootResponseParseError::ParsePayload))?;
 
             Self::from_parts(resp, data)
         }


### PR DESCRIPTION
There are cases, e.g. Spacemit K1 Bananapi F3 BootROM firmware, where the fastboot implementation can respond with a message body data that needs to be parsed as a NULL-terminated string, despite the bytes length of the response.

Following the protocol message description [0], this commit makes the data body to be parsed as a NULL-terminated string on all response types (OKAY, FAIL, INFO, TEXT) with the exception of DATA type, as this is raw data bytes.

Note that this matches the default official fastboot tool behavior.

[0] https://android.googlesource.com/platform/system/core/+/master/fastboot/README.md#transport-and-framing