### PR TITLE
fastboot-protocol: Support continue command on NusbFastBoot

### DIFF
--- a/fastboot-protocol/src/nusb.rs
+++ b/fastboot-protocol/src/nusb.rs
@@ -223,6 +223,14 @@ impl NusbFastBoot {
         })
     }
 
+    /// Continue booting
+    pub async fn continue_boot(&mut self) -> Result<(), NusbFastBootError> {
+        let cmd = FastBootCommand::<&str>::Continue;
+        self.execute(cmd).await.map(|v| {
+            trace!("Continue ok: {v}");
+        })
+    }
+
     /// Erasing the given target partition
     pub async fn erase(&mut self, target: &str) -> Result<(), NusbFastBootError> {
         let cmd = FastBootCommand::Erase(target);


### PR DESCRIPTION
The fastboot protocol already implements the `continue` command. Let's add this to the fastboot USB interface as well.